### PR TITLE
feat: Add bytes serializer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json="1.0"
 bincode = "1.3"
 bitvec = "1.0"
 byteorder = "1.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
+serde_json="1.0"
 bincode = "1.3"
 bitvec = "1.0"
 byteorder = "1.4.3"

--- a/src/fast_serde.rs
+++ b/src/fast_serde.rs
@@ -9,6 +9,7 @@
 //! the rust runtime.
 
 use std::io::{Cursor, Read};
+use thiserror::Error;
 
 pub static MAGIC_NUMBER: [u8; 4] = [0x50, 0x4C, 0x55, 0x54];
 pub enum SerdeByteTypes {
@@ -17,36 +18,26 @@ pub enum SerdeByteTypes {
     CommitmentKey = 0x03,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum SerdeByteError {
+    #[error("{}", "invalid magic number")]
     InvalidMagicNumber,
+    #[error("{}", "invalid serde type")]
     InvalidSerdeType,
+    #[error("{}", "invalid section count")]
     InvalidSectionCount,
+    #[error("{}", "invalid section type")]
     InvalidSectionType,
+    #[error("{}", "invalid section size")]
     InvalidSectionSize,
-    IoError(std::io::Error),
-    BincodeError(Box<bincode::ErrorKind>),
-    JsonError(serde_json::Error),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    BincodeError(#[from] Box<bincode::ErrorKind>),
+    #[error("{}", "g1 decode error")]
     G1DecodeError,
+    #[error("{}", "g2 decode error")]
     G2DecodeError,
-}
-
-impl From<std::io::Error> for SerdeByteError {
-    fn from(e: std::io::Error) -> Self {
-        SerdeByteError::IoError(e)
-    }
-}
-
-impl From<Box<bincode::ErrorKind>> for SerdeByteError {
-    fn from(error: Box<bincode::ErrorKind>) -> Self {
-        SerdeByteError::BincodeError(error)
-    }
-}
-
-impl From<serde_json::Error> for SerdeByteError {
-    fn from(error: serde_json::Error) -> Self {
-        SerdeByteError::JsonError(error)
-    }
 }
 
 /// A trait for fast conversions to bytes

--- a/src/fast_serde.rs
+++ b/src/fast_serde.rs
@@ -1,0 +1,107 @@
+//! This module implements fast serde for reading and writing
+//! key objects requires for proof generation and verification.
+//! With WASM in particular, serializing via standard binary serializers
+//! like bincode causes a dramatic decrease in performance. This simple
+//! serializers parses in bytes very efficiently.
+//!
+//! In the future, it can be extended to do direct memory access to the
+//! javascript runtime. For now it does a single copy of the data into
+//! the rust runtime.
+
+use std::io::{Cursor, Read};
+
+pub static MAGIC_NUMBER: [u8; 4] = [0x50, 0x4C, 0x55, 0x54];
+pub enum SerdeByteTypes {
+    AuxParams = 0x01,
+    UniversalKZGParam = 0x02,
+    CommitmentKey = 0x03,
+}
+
+#[derive(Debug)]
+pub enum SerdeByteError {
+    InvalidMagicNumber,
+    InvalidSerdeType,
+    InvalidSectionCount,
+    InvalidSectionType,
+    InvalidSectionSize,
+    IoError(std::io::Error),
+    BincodeError(Box<bincode::ErrorKind>),
+    JsonError(serde_json::Error),
+    G1DecodeError,
+    G2DecodeError,
+}
+
+impl From<std::io::Error> for SerdeByteError {
+    fn from(e: std::io::Error) -> Self {
+        SerdeByteError::IoError(e)
+    }
+}
+
+impl From<Box<bincode::ErrorKind>> for SerdeByteError {
+    fn from(error: Box<bincode::ErrorKind>) -> Self {
+        SerdeByteError::BincodeError(error)
+    }
+}
+
+impl From<serde_json::Error> for SerdeByteError {
+    fn from(error: serde_json::Error) -> Self {
+        SerdeByteError::JsonError(error)
+    }
+}
+
+/// A trait for fast conversions to bytes
+pub trait FastSerde: Sized {
+    fn to_bytes(&self) -> Vec<u8>;
+    fn from_bytes(bytes: &Vec<u8>) -> Result<Self, SerdeByteError>;
+
+    fn validate_header(
+        cursor: &mut Cursor<&Vec<u8>>,
+        expected_type: SerdeByteTypes,
+        expected_sections: u8,
+    ) -> Result<(), SerdeByteError> {
+        let mut magic = [0u8; 4];
+        cursor.read_exact(&mut magic)?;
+        if magic != MAGIC_NUMBER {
+            return Err(SerdeByteError::InvalidMagicNumber);
+        }
+
+        let mut serde_type = [0u8; 1];
+        cursor.read_exact(&mut serde_type)?;
+        if serde_type[0] != expected_type as u8 {
+            return Err(SerdeByteError::InvalidSerdeType);
+        }
+
+        let mut num_sections = [0u8; 1];
+        cursor.read_exact(&mut num_sections)?;
+        if num_sections[0] != expected_sections {
+            return Err(SerdeByteError::InvalidSectionCount);
+        }
+
+        Ok(())
+    }
+
+    fn read_section_bytes(
+        cursor: &mut Cursor<&Vec<u8>>,
+        expected_type: u8,
+    ) -> Result<Vec<u8>, SerdeByteError> {
+        let mut section_type = [0u8; 1];
+        cursor.read_exact(&mut section_type)?;
+        if section_type[0] != expected_type {
+            return Err(SerdeByteError::InvalidSectionType);
+        }
+
+        let mut section_size = [0u8; 4];
+        cursor.read_exact(&mut section_size)?;
+        let size = u32::from_le_bytes(section_size) as usize;
+        let mut section_data = vec![0u8; size];
+        cursor.read_exact(&mut section_data)?;
+
+        Ok(section_data)
+    }
+
+    fn write_section_bytes(out: &mut Vec<u8>, section_type: u8, data: &Vec<u8>) {
+        out.push(section_type);
+        out.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        out.extend_from_slice(data);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,7 +933,7 @@ pub fn circuit_digest<E1: CurveCycleEquipped, C: StepCircuit<E1::Scalar>>(
     cs.r1cs_shape().digest()
 }
 
-type CommitmentKey<E> = <<E as Engine>::CE as CommitmentEngineTrait<E>>::CommitmentKey;
+pub type CommitmentKey<E> = <<E as Engine>::CE as CommitmentEngineTrait<E>>::CommitmentKey;
 type Commitment<E> = <<E as Engine>::CE as CommitmentEngineTrait<E>>::Commitment;
 type CompressedCommitment<E> = <<<E as Engine>::CE as CommitmentEngineTrait<E>>::Commitment as CommitmentTrait<E>>::CompressedCommitment;
 type CE<E> = <E as Engine>::CE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod nifs;
 // public modules
 pub mod constants;
 pub mod errors;
+pub mod fast_serde;
 pub mod gadgets;
 pub mod provider;
 pub mod r1cs;

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -30,7 +30,7 @@ where
     E: Engine,
     E::GE: DlogGroup<ScalarExt = E::Scalar>,
 {
-    pub(in crate::provider) ck: Vec<<E::GE as PrimeCurve>::Affine>,
+    pub ck: Vec<<E::GE as PrimeCurve>::Affine>,
 }
 
 impl<E> Len for CommitmentKey<E>

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -4,17 +4,21 @@ use core::{
     marker::PhantomData,
     ops::{Add, Mul, MulAssign},
 };
+use std::io::Cursor;
 
 use ff::Field;
 use group::{
     prime::{PrimeCurve, PrimeCurveAffine},
     Curve, Group, GroupEncoding,
 };
+use halo2curves::serde::SerdeObject;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::NovaError,
+    fast_serde,
+    fast_serde::{FastSerde, SerdeByteError, SerdeByteTypes},
     provider::traits::DlogGroup,
     traits::{
         commitment::{CommitmentEngineTrait, CommitmentTrait, Len},
@@ -40,6 +44,62 @@ where
 {
     fn length(&self) -> usize {
         self.ck.len()
+    }
+}
+
+impl<E: Engine> FastSerde for CommitmentKey<E>
+where
+    <E::GE as PrimeCurve>::Affine: SerdeObject,
+    E::GE: DlogGroup<ScalarExt = E::Scalar>,
+{
+    /// Byte format:
+    ///
+    /// [0..4]   - Magic number (4 bytes)
+    /// [4]      - Serde type: CommitmentKey (u8)
+    /// [5]      - Number of sections (u8 = 1)
+    /// [6]      - Section 1 type: ck (u8)
+    /// [7..11]  - Section 1 size (u32)
+    /// [11..]   - Section 1 data
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+
+        out.extend_from_slice(&fast_serde::MAGIC_NUMBER);
+        out.push(fast_serde::SerdeByteTypes::CommitmentKey as u8);
+        out.push(1); // num_sections
+
+        Self::write_section_bytes(
+            &mut out,
+            1,
+            &self
+                .ck
+                .iter()
+                .flat_map(|p| p.to_raw_bytes())
+                .collect::<Vec<u8>>(),
+        );
+
+        out
+    }
+
+    fn from_bytes(bytes: &Vec<u8>) -> Result<Self, SerdeByteError> {
+        let mut cursor = Cursor::new(bytes);
+
+        // Validate header
+        Self::validate_header(&mut cursor, SerdeByteTypes::CommitmentKey, 1)?;
+
+        // Read ck section
+        let ck = Self::read_section_bytes(&mut cursor, 1)?
+            .chunks(
+                <E::GE as PrimeCurve>::Affine::identity()
+                    .to_raw_bytes()
+                    .len(),
+            )
+            .map(|bytes| {
+                <E::GE as PrimeCurve>::Affine::from_raw_bytes(bytes)
+                    .ok_or(SerdeByteError::G1DecodeError)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self { ck })
     }
 }
 

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -157,10 +157,6 @@ where
         out.push(8); // num_sections
 
         // Write sections
-        let circuit_shape = serde_json::to_string(&self.circuit_shape_secondary)
-            .unwrap()
-            .as_bytes()
-            .to_vec();
         Self::write_section_bytes(
             &mut out,
             1,
@@ -183,7 +179,7 @@ where
             &bincode::serialize(&self.ro_consts_circuit_secondary).unwrap(),
         );
         Self::write_section_bytes(&mut out, 6, &self.ck_secondary.to_bytes());
-        Self::write_section_bytes(&mut out, 7, &circuit_shape);
+        Self::write_section_bytes(&mut out, 7, &bincode::serialize(&self.circuit_shape_secondary).unwrap());
         Self::write_section_bytes(&mut out, 8, &bincode::serialize(&self.digest).unwrap());
 
         out
@@ -213,7 +209,7 @@ where
             &Self::read_section_bytes(&mut cursor, 6)?
         )?);
         let circuit_shape_secondary =
-            serde_json::from_slice(&Self::read_section_bytes(&mut cursor, 7)?)?;
+            bincode::deserialize(&Self::read_section_bytes(&mut cursor, 7)?)?;
         let digest = bincode::deserialize(&Self::read_section_bytes(&mut cursor, 8)?)?;
 
         // NOTE: This does not check the digest. Maybe we should.

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -34,10 +34,8 @@ use crate::{
 };
 
 mod circuit; // declare the module first
-pub use circuit::{StepCircuit, TrivialCircuit};
-use circuit::{
-    SuperNovaAugmentedCircuit, SuperNovaAugmentedCircuitInputs, SuperNovaAugmentedCircuitParams,
-};
+pub use circuit::{StepCircuit, SuperNovaAugmentedCircuitParams, TrivialCircuit};
+use circuit::{SuperNovaAugmentedCircuit, SuperNovaAugmentedCircuitInputs};
 use error::SuperNovaError;
 
 /// A struct that manages all the digests of the primary circuits of a SuperNova
@@ -105,18 +103,18 @@ pub struct AuxParams<E1>
 where
     E1: CurveCycleEquipped,
 {
-    ro_consts_primary: ROConstants<E1>,
-    ro_consts_circuit_primary: ROConstantsCircuit<Dual<E1>>,
-    ck_primary: Arc<CommitmentKey<E1>>, // This is shared between all circuit params
-    augmented_circuit_params_primary: SuperNovaAugmentedCircuitParams,
+    pub ro_consts_primary: ROConstants<E1>,
+    pub ro_consts_circuit_primary: ROConstantsCircuit<Dual<E1>>,
+    pub ck_primary: Arc<CommitmentKey<E1>>, // This is shared between all circuit params
+    pub augmented_circuit_params_primary: SuperNovaAugmentedCircuitParams,
 
-    ro_consts_secondary: ROConstants<Dual<E1>>,
-    ro_consts_circuit_secondary: ROConstantsCircuit<E1>,
-    ck_secondary: Arc<CommitmentKey<Dual<E1>>>,
-    circuit_shape_secondary: R1CSWithArity<Dual<E1>>,
-    augmented_circuit_params_secondary: SuperNovaAugmentedCircuitParams,
+    pub ro_consts_secondary: ROConstants<Dual<E1>>,
+    pub ro_consts_circuit_secondary: ROConstantsCircuit<E1>,
+    pub ck_secondary: Arc<CommitmentKey<Dual<E1>>>,
+    pub circuit_shape_secondary: R1CSWithArity<Dual<E1>>,
+    pub augmented_circuit_params_secondary: SuperNovaAugmentedCircuitParams,
 
-    digest: E1::Scalar,
+    pub digest: E1::Scalar,
 }
 
 impl<E1> Index<usize> for PublicParams<E1>
@@ -258,7 +256,8 @@ where
         (circuit_shapes, aux_params)
     }
 
-    /// Returns just the [`AuxParams`] portion of [`PublicParams`] from a reference to [`PublicParams`].
+    /// Returns just the [`AuxParams`] portion of [`PublicParams`] from a
+    /// reference to [`PublicParams`].
     pub fn aux_params(&self) -> AuxParams<E1> {
         AuxParams {
             ro_consts_primary: self.ro_consts_primary.clone(),


### PR DESCRIPTION
Add new serde methods for aux param and downstream objects. 

These are needed by the wasm runtime, which is very inefficient when using other forms of serialization like bincode/json, primarily due to the ck_primary object which is >100mb. 

Related work in [web-prover PR](https://github.com/pluto/web-prover/pull/329).